### PR TITLE
FIX: export staticRenderFns too

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -87,6 +87,7 @@ module.exports = function plugin(snowpackConfig) {
         }
         output['.js'].code += `\n${js.code}\n`;
         output['.js'].code += `\ndefaultExport.render = render`;
+        output['.js'].code += `\ndefaultExport.staticRenderFns = staticRenderFns`;
         output['.js'].code += `\nexport default defaultExport`;
 
         if ((sourcemap || sourceMaps) && js.map) output['.js'].map += JSON.stringify(js.map);


### PR DESCRIPTION
For simple template like (App.vue)

`<template><div><span>bla</span></div></template>`
`<script>
export default {}
</script>`

You received the following error:

vue.js:1882 TypeError: Cannot read property '0' of undefined
    at Proxy.renderStatic (vue.js:2805)
    at Proxy.render (main-page.vue.js:147)
    at VueComponent.Vue._render (vue.js:3536)
    at VueComponent.updateComponent (vue.js:4053)
    at Watcher.get (vue.js:4465)
    at new Watcher (vue.js:4454)
    at mountComponent (vue.js:4060)
    at VueComponent.Vue.$mount (vue.js:8392)
    at init (vue.js:3110)
    at createComponent (vue.js:5958)

OR if I've aliased vue -> "vue/dist/vue.esm.js" in snowpack.config.js
vue.esm.js:1891 TypeError: Cannot read property '0' of undefined
    at Proxy.renderStatic (vue.esm.js:2814)
    at Proxy.render (main-page.vue.js:147)
    at VueComponent.Vue._render (vue.esm.js:3545)
    at VueComponent.updateComponent (vue.esm.js:4062)
    at Watcher.get (vue.esm.js:4474)
    at new Watcher (vue.esm.js:4463)
    at mountComponent (vue.esm.js:4069)
    at VueComponent.Vue.$mount (vue.esm.js:9040)
    at VueComponent.Vue.$mount (vue.esm.js:11941)
    at init (vue.esm.js:3119)

From my package.json:
"@snowpack/plugin-dotenv": "^2.0.5",
"@snowpack/plugin-sass": "^1.3.0",
"@snowpack/plugin-typescript": "^1.2.1",
"snowpack": "^3.0.11",
"snowpack-vue2-plugin": "0.0.5",
 "vue": "^2.6.12",
 "vuetify": "^2.4.2",
